### PR TITLE
Docker api test setup and some automation tests

### DIFF
--- a/api/tacticalrmm/automation/tests.py
+++ b/api/tacticalrmm/automation/tests.py
@@ -1,3 +1,82 @@
-from django.test import TestCase
+from rest_framework import status
+from django.urls import reverse
 
-# Create your tests here.
+from tacticalrmm.test import BaseTestCase
+from .serializers import PolicyTableSerializer, PolicySerializer
+
+from unittest.mock import patch
+
+
+class TestPolicyViews(BaseTestCase):
+    def test_get_all_policies(self):
+        url = "/automation/policies/"
+
+        resp = self.client.get(url, format="json")
+        serializer = PolicyTableSerializer([self.policy], many=True)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, serializer.data)
+        self.check_not_authenticated("get", url)
+
+    def test_get_policy(self):
+        url = f"/automation/policies/{self.policy.pk}/"
+
+        resp = self.client.get(url, format="json")
+        serializer = PolicySerializer(self.policy)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, serializer.data)
+
+        # returns 404 for invalid policy pk
+        resp = self.client.get("/automation/policies/500/", format="json")
+        self.assertEqual(resp.status_code, 404)
+        self.check_not_authenticated("get", "/automation/policies/500/")
+
+    def test_add_policy(self):
+        url = "/automation/policies/"
+
+        valid_payload = {
+            "name": "Test Policy",
+            "desc": "policy desc",
+            "active": True,
+            "enforced": False
+        }
+
+        resp = self.client.post(url, valid_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+        # running again should fail since names are unique
+        resp = self.client.post(url, valid_payload, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+        self.check_not_authenticated("post", url)
+
+    @patch('automation.tasks.generate_agent_checks_from_policies_task.delay')
+    def test_update_policy(self, mock_task):
+        url = f"/automation/policies/{self.policy.pk}/"
+
+        valid_payload = {
+            "name": "Test Policy Update",
+            "desc": "policy desc Update",
+            "active": True,
+            "enforced": False
+        }
+
+        resp = self.client.put(url, valid_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+        # only called if active or enforced are updated
+        mock_task.assert_not_called()
+
+        valid_payload = {
+            "name": "Test Policy Update",
+            "desc": "policy desc Update",
+            "active": False,
+            "enforced": False
+        }
+
+        resp = self.client.put(url, valid_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        mock_task.assert_called_with(policypk=self.policy.pk)
+
+        self.check_not_authenticated("put", url)

--- a/api/tacticalrmm/tacticalrmm/test.py
+++ b/api/tacticalrmm/tacticalrmm/test.py
@@ -1,8 +1,6 @@
 from django.test import TestCase
 from django.utils import timezone as djangotime
 
-from unittest.mock import patch
-
 from rest_framework.test import APIClient
 from rest_framework.test import force_authenticate
 

--- a/docker/api-test/dockerfile
+++ b/docker/api-test/dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.7
+
+WORKDIR /app
+
+COPY ./api/tacticalrmm/requirements.txt .
+
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt
+
+COPY ./api/tacticalrmm/ .
+
+RUN rm ./tacticalrmm/local_settings.py && \
+    rm ./tacticalrmm/settings.py
+
+COPY ./docker/api-test/settings.py ./tacticalrmm/
+CMD python manage.py test -v 2

--- a/docker/api-test/settings.py
+++ b/docker/api-test/settings.py
@@ -1,0 +1,140 @@
+    
+import os
+from datetime import timedelta
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+LOG_DIR = os.path.join(BASE_DIR, "tacticalrmm/private/log")
+
+EXE_DIR = os.path.join(BASE_DIR, "tacticalrmm/private/exe")
+
+AUTH_USER_MODEL = "accounts.User"
+
+APP_VER = "0.0.1"
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "rest_framework",
+    "rest_framework.authtoken",
+    "knox",
+    "corsheaders",
+    "accounts",
+    "api",
+    "clients",
+    "agents",
+    "checks",
+    "services",
+    "winupdate",
+    "software",
+    "core",
+    "automation",
+    "autotasks",
+    "logs",
+    "scripts",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",  ##
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+]
+
+
+REST_KNOX = {
+    "TOKEN_TTL": timedelta(hours=5),
+    "AUTO_REFRESH": True,
+    "MIN_REFRESH_INTERVAL": 600,
+}
+
+ROOT_URLCONF = "tacticalrmm.urls"
+
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = "tacticalrmm.wsgi.application"
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",},
+]
+
+
+LANGUAGE_CODE = "en-us"
+
+TIME_ZONE = "UTC"
+
+USE_I18N = True
+
+USE_L10N = True
+
+USE_TZ = True
+
+
+STATIC_URL = "/static/"
+
+STATIC_ROOT = os.path.join(BASE_DIR, "static")
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "tacticalrmm/static/")]
+
+
+LOG_CONFIG = {
+    "handlers": [{"sink": os.path.join(LOG_DIR, "debug.log"), "serialize": False}]
+}   
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "tacticalrmm-test",
+        "USER": "test",
+        "PASSWORD": "testpass",
+        "HOST": "db-test",
+        "PORT": "5432",
+    }
+}
+
+REST_FRAMEWORK = {
+    "DATETIME_FORMAT": "%b-%d-%Y - %H:%M",
+    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
+    "DEFAULT_AUTHENTICATION_CLASSES": ("knox.auth.TokenAuthentication",),
+    "DEFAULT_RENDERER_CLASSES": ("rest_framework.renderers.JSONRenderer",),
+}
+
+DEBUG = True
+SECRET_KEY = "abcdefghijklmnoptravis123456789"
+
+ADMIN_URL = "abc123456/"
+
+SALT_USERNAME = "test"
+SALT_PASSWORD = "testpass"
+MESH_USERNAME = "test"
+MESH_SITE = "https://example.com"
+MESH_TOKEN_KEY = "bd65e957a1e70c622d32523f61508400d6cd0937001a7ac12042227eba0b9ed625233851a316d4f489f02994145f74537a331415d00047dbbf13d940f556806dffe7a8ce1de216dc49edbad0c1a7399c"
+REDIS_HOST = "redis-test"
+SALT_HOST = "salt"

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -1,6 +1,9 @@
 # FOR TESTS 
 version: '3.7'
 
+networks: 
+  test:
+
 services:
   # Container that hosts Vue frontend
   app-unit-test:
@@ -9,3 +12,31 @@ services:
     working_dir: /home/node
     volumes:
       - ../web:/home/node
+    networks: 
+      - test
+  
+  api-test:
+    build:
+      context: ..
+      dockerfile: ./docker/api-test/dockerfile
+    depends_on: 
+      - db-test
+      - redis-test
+    networks: 
+      - test
+
+  # Postgres Database for API service
+  db-test:
+    image: postgres:11.7
+    environment: 
+      POSTGRES_DB: tacticalrmm-test
+      POSTGRES_USER: test
+      POSTGRES_PASSWORD: testpass
+    networks: 
+      - test
+
+  # Redis Container for Celery tasks
+  redis-test:
+    image: redis
+    networks: 
+      - test


### PR DESCRIPTION
So I recreated the py virtual env and recreated the container and now the cpuload and memory checks are working! I think most of the bugs are ironed out it can just be optimized a bunch.

Started on some API tests and starting to get more familiar with the unittest package. Can also run the API tests in isolation within the new docker containers.

Should I do the same thing with the autotasks? Do you think the policy checks setup can be improved?
