### PR TITLE
Policy Check Improvements and Test

### DIFF
--- a/api/tacticalrmm/agents/models.py
+++ b/api/tacticalrmm/agents/models.py
@@ -192,9 +192,15 @@ class Agent(models.Model):
         except:
             return [{"model": "unknown", "size": "unknown", "interfaceType": "unknown"}]
 
-    def generate_checks_from_policies(self):
+    # clear is used to delete managed policy checks from agent
+    # parent_checks specifies a list of checks to delete from agent with matching parent_check field
+    def generate_checks_from_policies(self, clear=False, parent_checks=[]):
         # Clear agent checks managed by policy
-        self.agentchecks.filter(managed_by_policy=True).delete()
+        if clear:
+            if parent_checks:
+                self.agentchecks.filter(managed_by_policy=True).filter(parent_checks__in=parent_checks).delete()
+            else:
+                self.agentchecks.filter(managed_by_policy=True).delete()
 
         # Clear agent checks that have overriden_by_policy set
         self.agentchecks.update(overriden_by_policy=False)

--- a/api/tacticalrmm/automation/models.py
+++ b/api/tacticalrmm/automation/models.py
@@ -40,6 +40,8 @@ class Policy(models.Model):
         # Get checks added to agent directly
         agent_checks = list(agent.agentchecks.filter(managed_by_policy=False))
 
+        agent_checks_parent_pks = [check.parent_check for check in agent.agentchecks.filter(managed_by_policy=True)]
+
         # Get policies applied to agent and agent site and client
         client = Client.objects.get(client=agent.client)
         site = Site.objects.filter(client=client).get(site=agent.site)
@@ -173,7 +175,7 @@ class Policy(models.Model):
                     check.overriden_by_policy = True
                     check.save()
 
-        return (
+        final_list = (
             diskspace_checks
             + ping_checks
             + cpuload_checks
@@ -182,6 +184,8 @@ class Policy(models.Model):
             + script_checks
             + eventlog_checks
         )
+
+        return [check for check in final_list if check.pk not in agent_checks_parent_pks]
 
     @staticmethod
     def generate_policy_checks(agent):

--- a/api/tacticalrmm/automation/tasks.py
+++ b/api/tacticalrmm/automation/tasks.py
@@ -1,20 +1,28 @@
 from automation.models import Policy
 from checks.models import Check
+from agents.models import Agent
 from tacticalrmm.celery import app
 
 
 @app.task
-def generate_agent_checks_from_policies_task(policypk, many=False):
+def generate_agent_checks_from_policies_task(policypk, many=False, clear=False, parent_checks=[]):
 
     if many:
         policy_list = Policy.objects.filter(pk__in=policypk)
         for policy in policy_list:
             for agent in policy.related_agents():
-                agent.generate_checks_from_policies()
+                agent.generate_checks_from_policies(clear=clear, parent_checks=parent_checks)
     else:
         policy = Policy.objects.get(pk=policypk)
         for agent in policy.related_agents():
-            agent.generate_checks_from_policies()
+            agent.generate_checks_from_policies(clear=clear, parent_checks=parent_checks)
+
+@app.task
+def generate_agent_checks_by_location_task(location, clear=False, parent_checks=[]):
+
+    policy = Policy.objects.get(pk=policypk)
+    for agent in Agent.objects.filter(**location):
+        agent.generate_checks_from_policies(clear=clear, parent_checks=parent_checks)
 
 @app.task
 def delete_policy_check_task(checkpk):

--- a/api/tacticalrmm/automation/tests.py
+++ b/api/tacticalrmm/automation/tests.py
@@ -1,10 +1,23 @@
 from rest_framework import status
 from django.urls import reverse
 
-from tacticalrmm.test import BaseTestCase
-from .serializers import PolicyTableSerializer, PolicySerializer
-
 from unittest.mock import patch
+from tacticalrmm.test import BaseTestCase
+
+from .serializers import (
+    PolicyTableSerializer,
+    PolicySerializer,
+    AutoTaskPolicySerializer,
+    PolicyOverviewSerializer,
+    PolicyCheckStatusSerializer
+)
+
+from checks.serializers import CheckSerializer
+
+from automation.models import Policy
+from checks.models import Check
+from autotasks.models import AutomatedTask
+from clients.models import Client, Site
 
 
 class TestPolicyViews(BaseTestCase):
@@ -30,6 +43,7 @@ class TestPolicyViews(BaseTestCase):
         # returns 404 for invalid policy pk
         resp = self.client.get("/automation/policies/500/", format="json")
         self.assertEqual(resp.status_code, 404)
+
         self.check_not_authenticated("get", "/automation/policies/500/")
 
     def test_add_policy(self):
@@ -77,6 +91,262 @@ class TestPolicyViews(BaseTestCase):
 
         resp = self.client.put(url, valid_payload, format="json")
         self.assertEqual(resp.status_code, 200)
-        mock_task.assert_called_with(policypk=self.policy.pk)
+        mock_task.assert_called_with(policypk=self.policy.pk, clear=True)
 
         self.check_not_authenticated("put", url)
+
+    @patch("automation.tasks.generate_agent_checks_from_policies_task.delay")
+    def test_delete_policy(self, mock_task):
+        url = f"/automation/policies/{self.policy.pk}/"
+
+        resp = self.client.delete(url, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+        mock_task.assert_called_with(policypk=self.policy.pk, clear=True)
+
+        self.check_not_authenticated("delete", url)
+
+    def test_get_all_policy_tasks(self):
+        url = f"/automation/{self.policy.pk}/policyautomatedtasks/"
+
+        resp = self.client.get(url, format="json")
+        serializer = AutoTaskPolicySerializer(self.policy)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, serializer.data)
+        self.check_not_authenticated("get", url)
+
+    def test_get_all_policy_checks(self):
+        url = f"/automation/{self.policy.pk}/policychecks/"
+
+        resp = self.client.get(url, format="json")
+        serializer = CheckSerializer([self.policyDiskCheck], many=True)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, serializer.data)
+        self.check_not_authenticated("get", url)
+
+    def test_get_policy_check_status(self):
+        url = f"/automation/policycheckstatus/{self.policyDiskCheck.pk}/check/"
+
+        # create managed policy check
+        self.policyDiskCheck.create_policy_check(self.agent)
+
+        # see if managed policy check exists
+        checks = Check.objects.filter(parent_check=self.policyDiskCheck.pk)
+        self.assertTrue(checks.exists())
+
+        resp = self.client.patch(url, format="json")
+        serializer = PolicyCheckStatusSerializer(checks, many=True)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, serializer.data)
+        self.check_not_authenticated("patch", url)
+
+    def test_policy_overview(self):
+        url = "/automation/policies/overview/"
+
+        clients = Client.objects.all()
+
+        resp = self.client.get(url, format="json")
+        serializer = PolicyOverviewSerializer(clients, many=True)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, serializer.data)
+        self.check_not_authenticated("get", url)
+
+    def test_get_related(self):
+        url = f"/automation/policies/{self.policy.pk}/related/"
+
+        resp = self.client.get(url, format="json")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsInstance(resp.data["clients"], type([]))
+        self.assertIsInstance(resp.data["sites"], type([]))
+        self.assertIsInstance(resp.data["agents"], type([]))
+
+        self.check_not_authenticated("get", url)
+
+    @patch("agents.models.Agent.generate_checks_from_policies")
+    @patch("automation.tasks.generate_agent_checks_by_location_task.delay")
+    def test_update_policy_add(self, mock_task, mock_agent_generate_checks):
+        url = f"/automation/related/"
+
+        # data setup
+        policy = Policy.objects.create(name="Test Policy")
+        client = Client.objects.create(client="Test Client")
+        site = Site.objects.create(client=client, site="Test Site")
+
+        # test add client to policy
+        client_payload = {
+            "type": "client",
+            "pk": client.pk,
+            "policy": policy.pk
+        }
+
+        # test add site to policy
+        site_payload = {
+            "type": "site",
+            "pk": site.pk,
+            "policy": policy.pk
+        }
+
+        # test add agent to policy
+        agent_payload = {
+            "type": "agent",
+            "pk": self.agent.pk,
+            "policy": policy.pk
+        }
+
+        # test client add
+        resp = self.client.post(url, client_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        # called because the relation changed
+        mock_task.assert_called_with(location={"client": client.pk}, clear=True)
+        mock_task.reset_mock()
+
+        # test site add
+        resp = self.client.post(url, site_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        # called because the relation changed
+        mock_task.assert_called_with(location={"client": site.client.client, "site": site.pk}, clear=True)
+        mock_task.reset_mock()
+
+        # test agent add
+        resp = self.client.post(url, agent_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        # called because the relation changed
+        mock_agent_generate_checks.assert_called_with(clear=True)
+        mock_agent_generate_checks.reset_mock()
+
+        # Adding the same relations shouldn't trigger mocks
+        resp = self.client.post(url, client_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        mock_task.assert_not_called()
+
+        resp = self.client.post(url, site_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        mock_task.assert_not_called()
+
+        resp = self.client.post(url, agent_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        # called because the relation changed
+        mock_agent_generate_checks.assert_not_called()
+
+        # test remove client from policy
+        client_payload = {
+            "type": "client",
+            "pk": client.pk,
+            "policy": 0
+        }
+
+        # test remove site from policy
+        site_payload = {
+            "type": "site",
+            "pk": site.pk,
+            "policy": 0
+        }
+
+        # test remove agent from policy
+        agent_payload = {
+            "type": "agent",
+            "pk": self.agent.pk,
+            "policy": 0
+        }
+
+        # test client remove
+        resp = self.client.post(url, client_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        # called because the relation changed
+        mock_task.assert_called_with(location={"client": client.pk}, clear=True)
+        mock_task.reset_mock()
+
+        # test site remove
+        resp = self.client.post(url, site_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        # called because the relation changed
+        mock_task.assert_called_with(location={"client": site.client.client, "site": site.pk}, clear=True)
+        mock_task.reset_mock()
+
+        # test agent remove
+        resp = self.client.post(url, agent_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        # called because the relation changed
+        mock_agent_generate_checks.assert_called_with(clear=True)
+        mock_agent_generate_checks.reset_mock()
+
+        # adding the same relations shouldn't trigger mocks
+        resp = self.client.post(url, client_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        # shouldn't be called since nothing changed
+        mock_task.assert_not_called()
+
+        resp = self.client.post(url, site_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        # shouldn't be called since nothing changed
+        mock_task.assert_not_called()
+
+        resp = self.client.post(url, agent_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        # shouldn't be called since nothing changed
+        mock_agent_generate_checks.assert_not_called()
+
+        self.check_not_authenticated("post", url)
+
+    def test_relation_by_type(self):
+        url = f"/automation/related/"
+
+        # data setup
+        policy = Policy.objects.create(name="Test Policy")
+        client = Client.objects.create(client="Test Client")
+        site = Site.objects.create(client=client, site="Test Site")
+
+        policy.clients.add(client)
+        policy.sites.add(site)
+        policy.agents.add(self.agent)
+
+        client_payload = {
+            "type": "client",
+            "pk": client.pk
+        }
+
+        # test add site to policy
+        site_payload = {
+            "type": "site",
+            "pk": site.pk
+        }
+
+        # test add agent to policy
+        agent_payload = {
+            "type": "agent",
+            "pk": self.agent.pk
+        }
+
+        # test client relation get
+        serializer = PolicySerializer(policy)
+        resp = self.client.patch(url, client_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, serializer.data)
+        
+        # test site relation get
+        serializer = PolicySerializer(policy)
+        resp = self.client.patch(url, site_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, serializer.data)
+
+        # test agent relation get
+        serializer = PolicySerializer(policy)
+        resp = self.client.patch(url, agent_payload, format="json")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.data, serializer.data)
+
+
+        invalid_payload = {
+            "type": "bad_type",
+            "pk": 5
+        }
+
+        resp = self.client.patch(url, invalid_payload, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+        self.check_not_authenticated("patch", url)

--- a/api/tacticalrmm/checks/models.py
+++ b/api/tacticalrmm/checks/models.py
@@ -268,6 +268,28 @@ class Check(models.Model):
             fail_when=self.fail_when,
             search_last_days=self.search_last_days,
         )
+    
+    def is_duplicate(self, check):
+        if self.check_type == "diskspace":
+            return self.disk == check.disk
+
+        elif self.check_type == "script":
+            return self.script == check.script
+
+        elif self.check_type == "ping":
+            return self.ip == check.ip
+
+        elif self.check_type == "cpuload":
+            return True
+
+        elif self.check_type == "memory":
+            return True
+
+        elif self.check_type == "winsvc":
+            return self.svc_name == check.svc_name
+
+        elif self.check_type == "eventlog":
+            return [self.log_name, self.event_id] == [check.log_name, check.event_id]
 
     def send_email(self):
 

--- a/api/tacticalrmm/checks/views.py
+++ b/api/tacticalrmm/checks/views.py
@@ -62,8 +62,19 @@ class GetAddCheck(APIView):
         if policy:
             generate_agent_checks_from_policies_task.delay(policypk=policy.pk)
         elif agent:
-            agent.generate_checks_from_policies()
+            checks = agent.agentchecks.filter(check_type=obj.check_type, managed_by_policy=True)
+            
+            # Should only be one
+            duplicate_check = [check for check in checks if check.is_duplicate(obj)]
 
+            if duplicate_check:
+                policy = Check.objects.get(pk=duplicate_check[0].parent_check).policy
+                if policy.enforced:
+                    obj.overriden_by_policy=True
+                    obj.save()
+                else:
+                    duplicate_check[0].delete()
+            
         return Response(f"{obj.readable_desc} was added!")
 
 
@@ -92,19 +103,24 @@ class GetUpdateDeleteCheck(APIView):
     def delete(self, request, pk):
         check = get_object_or_404(Check, pk=pk)
 
+        check_pk = check.pk
+        policy_pk = None
+        if check.policy:
+            policy_pk = check.policy.pk
+
+        check.delete()
+
         # Policy check deleted
         if check.policy:
-            delete_policy_check_task.delay(checkpk=check.pk)
+            delete_policy_check_task.delay(checkpk=check_pk)
 
             # Re-evaluate agent checks is policy was enforced
             if check.policy.enforced:
-                generate_agent_checks_from_policies_task.delay(policypk=check.policy.pk)
+                generate_agent_checks_from_policies_task.delay(policypk=policy_pk)
 
         # Agent check deleted
         elif check.agent:
             check.agent.generate_checks_from_policies()
-
-        check.delete()
         
         return Response(f"{check.readable_desc} was deleted!")
 

--- a/api/tacticalrmm/tacticalrmm/test.py
+++ b/api/tacticalrmm/tacticalrmm/test.py
@@ -11,6 +11,7 @@ from clients.models import Client, Site
 from automation.models import Policy
 from core.models import CoreSettings
 from checks.models import Check
+from autotasks.models import AutomatedTask
 
 
 class BaseTestCase(TestCase):
@@ -107,6 +108,11 @@ class BaseTestCase(TestCase):
             disk="M:",
             threshold=87,
             fails_b4_alert=1,
+        )
+
+        self.policyTask = AutomatedTask.objects.create(
+            policy=self.policy, 
+            name="Test Task"
         )
 
     def check_not_authenticated(self, method, url):

--- a/web/src/components/automation/PolicyAutomatedTasksTab.vue
+++ b/web/src/components/automation/PolicyAutomatedTasksTab.vue
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-12">
       <q-btn
+        v-if="selectedPolicy !== null"
         size="sm"
         color="grey-5"
         icon="fas fa-plus"
@@ -11,11 +12,13 @@
         @click="showAddAutomatedTask = true"
       />
       <q-btn 
-        dense 
-        flat push 
-        @click="refreshTasks(selectedPolicy)" 
+        v-if="selectedPolicy !== null"
+        dense
+        flat
+        push
+        @click="refreshTasks(selectedPolicy)"
         icon="refresh"
-        ref="refresh" 
+        ref="refresh"
       />
       <template>
         <q-table

--- a/web/src/components/automation/PolicyChecksTab.vue
+++ b/web/src/components/automation/PolicyChecksTab.vue
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-12">
       <q-btn
+        v-if="selectedPolicy !== null"
         size="sm"
         color="grey-5"
         icon="fas fa-plus"
@@ -56,7 +57,15 @@
           </q-list>
         </q-menu>
       </q-btn>
-      <q-btn dense flat push @click="onRefresh(selectedPolicy)" icon="refresh" ref="refresh" />
+      <q-btn 
+        v-if="selectedPolicy !== null" 
+        dense 
+        flat 
+        push
+        @click="onRefresh(selectedPolicy)" 
+        icon="refresh" 
+        ref="refresh" 
+      />
       <template>
         <q-table
           dense

--- a/web/test/jest/__tests__/automation/policycheckstab.spec.js
+++ b/web/test/jest/__tests__/automation/policycheckstab.spec.js
@@ -72,6 +72,12 @@ describe("PolicyChecksTab.vue with no policy selected", () => {
     expect(wrapper.html()).toContain("Click on a policy to see the checks");
   });
 
+  it("doesn't show refresh or add button when no policy selected", () => {
+
+    expect(wrapper.findComponent({ ref: "refresh" }).exists()).toBe(false)
+    expect(wrapper.findComponent({ ref: "add" }).exists()).toBe(false)
+  });
+
 });
 
 describe("PolicyChecksTab.vue with policy selected and no checks", () => {
@@ -339,7 +345,8 @@ describe("PolicyChecksTab.vue with policy selected and checks", () => {
       { 
         pk: 1,
           data: {
-            text_alert: true
+            text_alert: true,
+            check_alert: true
           }
       }
       );
@@ -352,7 +359,8 @@ describe("PolicyChecksTab.vue with policy selected and checks", () => {
       { 
         pk: 1,
           data: {
-            text_alert: false
+            text_alert: false,
+            check_alert: true
           }
       }
     );
@@ -372,7 +380,8 @@ describe("PolicyChecksTab.vue with policy selected and checks", () => {
       { 
         pk: 1,
           data: {
-            email_alert: true
+            email_alert: true,
+            check_alert: true
           }
       }
     );
@@ -385,7 +394,8 @@ describe("PolicyChecksTab.vue with policy selected and checks", () => {
       { 
         pk: 1,
           data: {
-            email_alert: false
+            email_alert: false,
+            check_alert: true
           }
       }
     );

--- a/web/test/jest/__tests__/automation/policytasksstab.spec.js
+++ b/web/test/jest/__tests__/automation/policytasksstab.spec.js
@@ -66,6 +66,12 @@ describe("PolicyAutomatedTasksTab.vue with no policy selected", () => {
     expect(wrapper.html()).toContain("Click on a policy to see the tasks");
   });
 
+  it("doesn't show refresh or add button when no policy selected", () => {
+
+    expect(wrapper.findComponent({ ref: "refresh" }).exists()).toBe(false)
+    expect(wrapper.findComponent({ ref: "add" }).exists()).toBe(false)
+  });
+
 });
 
 describe("PolicyAutomatedTasksTab.vue with policy selected and no tasks", () => {


### PR DESCRIPTION
Here are some more improvements and tests! Let me know when you want to update to python 3.8. It should be as easy as updating the tags in the docker-compose and dockerfile for python version.

So far, Policy checks it will only delete and rerun all checks when:

- Policy is activated
- Agent, Site, or client are added to a policy (Will only affect agents actually in Site or Client)
- Policy enforcement is disabled

I tests the override policies and that seems to be working.

To disable the editing of policy checks on the agent checks table, I was thinking of adding a "readonly" prop to the check form modals that will disable the fields. Or graying out the context menus might work, but the @click action might still trigger.

I did write some tests for the automation views and was surprised to see that the tests were about 100 lines of code longer than the actual view! But I might be doing it wrong lol.

I was checking out the autotasks and noticed that it is setup similar to how the checks used to be. The view returns the agent model with an autotasks field. Is that eventually going to be reworked? If so I can try and tackle that when I setup the policy tasks. 