### PR TITLE
Change the front end example from app to rmm

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,7 @@ done
 
 while [[ $frontenddomain != *[.]*[.]* ]]
 do
-echo -ne "${YELLOW}Enter the subdomain for the frontend (e.g. app.example.com)${NC}: "
+echo -ne "${YELLOW}Enter the subdomain for the frontend (e.g. rmm.example.com)${NC}: "
 read frontenddomain
 done
 


### PR DESCRIPTION
The readme instructions state that you should create rmm.example.com as an A record, but the installer uses app.example.com as an example, which is just a bit confusing during the install process.