### PR TITLE
Allow bulk resetting agent policies from settings UI. Modified agent edit serializer to fix errors

### DIFF
--- a/api/tacticalrmm/agents/serializers.py
+++ b/api/tacticalrmm/agents/serializers.py
@@ -64,6 +64,31 @@ class AgentTableSerializer(serializers.ModelSerializer):
             "logged_in_username",
         ]
 
+class AgentEditSerializer(serializers.ModelSerializer):
+    winupdatepolicy = WinUpdatePolicySerializer(many=True, read_only=True)
+    all_timezones = serializers.SerializerMethodField()
+
+    def get_all_timezones(self, obj):
+        return pytz.all_timezones
+
+    class Meta:
+        model = Agent
+        fields = [
+            "id",
+            "hostname",
+            "client",
+            "site",
+            "monitoring_type",
+            "description",
+            "time_zone",
+            "timezone",
+            "check_interval",
+            "overdue_time",
+            "overdue_text_alert",
+            "overdue_email_alert",
+            "all_timezones",
+            "winupdatepolicy",
+        ]
 
 class WinAgentSerializer(serializers.ModelSerializer):
     # for the windows agent

--- a/api/tacticalrmm/agents/urls.py
+++ b/api/tacticalrmm/agents/urls.py
@@ -4,6 +4,7 @@ from . import views
 urlpatterns = [
     path("listagents/", views.list_agents),
     path("listagentsnodetail/", views.list_agents_no_detail),
+    path("<int:pk>/agenteditdetails/", views.agent_edit_details),
     path("byclient/<client>/", views.by_client),
     path("bysite/<client>/<site>/", views.by_site),
     path("overdueaction/", views.overdue_action),

--- a/api/tacticalrmm/agents/views.py
+++ b/api/tacticalrmm/agents/views.py
@@ -28,7 +28,7 @@ from accounts.models import User
 from core.models import CoreSettings
 from scripts.models import Script
 
-from .serializers import AgentSerializer, AgentHostnameSerializer, AgentTableSerializer
+from .serializers import AgentSerializer, AgentHostnameSerializer, AgentTableSerializer, AgentEditSerializer
 from winupdate.serializers import WinUpdatePolicySerializer
 
 from .tasks import uninstall_agent_task, send_agent_update_task
@@ -240,6 +240,10 @@ def list_agents_no_detail(request):
     agents = Agent.objects.all()
     return Response(AgentHostnameSerializer(agents, many=True).data)
 
+@api_view()
+def agent_edit_details(request, pk):
+    agent = get_object_or_404(Agent, pk=pk)
+    return Response(AgentEditSerializer(agent).data)
 
 @api_view()
 def by_client(request, client):

--- a/api/tacticalrmm/automation/urls.py
+++ b/api/tacticalrmm/automation/urls.py
@@ -14,4 +14,5 @@ urlpatterns = [
     path("runwintask/<int:task>/", views.PolicyAutoTask.as_view()),
     path("winupdatepolicy/", views.UpdatePatchPolicy.as_view()),
     path("winupdatepolicy/<int:patchpolicy>/", views.UpdatePatchPolicy.as_view()),
+    path("winupdatepolicy/reset/", views.UpdatePatchPolicy.as_view()),
 ]

--- a/api/tacticalrmm/automation/views.py
+++ b/api/tacticalrmm/automation/views.py
@@ -401,6 +401,28 @@ class UpdatePatchPolicy(APIView):
 
         return Response("ok")
 
+    def patch(self, request):
+        
+        agents = None
+        if "client" in request.data and "site" in request.data:
+            agents = Agent.objects.filter(client=request.data["client"], site=request.data["site"])
+        elif "client" in request.data:
+            agents = Agent.objects.filter(client=request.data["client"])
+        else:
+            agents = Agent.objects.all()
+
+        for agent in agents:
+            winupdatepolicy = agent.winupdatepolicy.get()
+            winupdatepolicy.critical = "inherit"
+            winupdatepolicy.important = "inherit"
+            winupdatepolicy.moderate = "inherit"
+            winupdatepolicy.low = "inherit"
+            winupdatepolicy.other = "inherit"
+            winupdatepolicy.save(update_fields=["critical", "important", "moderate", "low", "other"])
+
+        return Response("ok")
+
+
     # delete patch policy
     def delete(self, request, patchpolicy):
         get_object_or_404(WinUpdatePolicy, pk=patchpolicy).delete()

--- a/api/tacticalrmm/automation/views.py
+++ b/api/tacticalrmm/automation/views.py
@@ -52,7 +52,54 @@ class GetAddPolicies(APIView):
     def post(self, request):
         serializer = PolicySerializer(data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
-        serializer.save()
+        policy = serializer.save()
+
+        # copy checks and tasks from specified policy
+        if "copyId" in request.data:
+            copyPolicy = Policy.objects.get(pk=request.data["copyId"])
+
+            checks = copyPolicy.policychecks.all()
+            for check in checks:
+                Check.objects.create(
+                    policy=policy,
+                    name=check.name,
+                    check_type=check.check_type,
+                    email_alert=check.email_alert,
+                    text_alert=check.text_alert,
+                    fails_b4_alert=check.fails_b4_alert,
+                    extra_details=check.extra_details,
+                    threshold=check.threshold,
+                    disk=check.disk,
+                    ip=check.ip,
+                    script=check.script,
+                    timeout=check.timeout,
+                    svc_name=check.svc_name,
+                    svc_display_name=check.svc_display_name,
+                    pass_if_start_pending=check.pass_if_start_pending,
+                    restart_if_stopped=check.restart_if_stopped,
+                    svc_policy_mode=check.svc_policy_mode,
+                    log_name=check.log_name,
+                    event_id=check.event_id,
+                    event_type=check.event_type,
+                    fail_when=check.fail_when,
+                    search_last_days=check.search_last_days,
+                )
+            
+            tasks = copyPolicy.autotasks.all()
+
+            for task in tasks:
+                task = AutomatedTask.objects.create(
+                    policy=policy,
+                    script=task.script,
+                    assigned_check=task.assigned_check,
+                    name=task.name,
+                    run_time_days=task.run_time_days,
+                    run_time_minute=task.run_time_minute,
+                    task_type=task.task_type,
+                    win_task_name=task.win_task_name,
+                    timeout=task.timeout,
+                    enabled=task.enabled,
+                )
 
         return Response("ok")
 

--- a/api/tacticalrmm/clients/serializers.py
+++ b/api/tacticalrmm/clients/serializers.py
@@ -2,7 +2,22 @@ from rest_framework.serializers import ModelSerializer, ReadOnlyField, Validatio
 from .models import Client, Site
 
 
+class SiteSerializer(ModelSerializer):
+    class Meta:
+        model = Site
+        fields = "__all__"
+
+    def validate(self, val):
+        if "|" in val["site"]:
+            raise ValidationError("Site name cannot contain the | character")
+
+        return val
+
+
 class ClientSerializer(ModelSerializer):
+
+    sites = SiteSerializer(many=True, read_only=True)
+
     class Meta:
         model = Client
         fields = "__all__"
@@ -17,18 +32,6 @@ class ClientSerializer(ModelSerializer):
 
         if "|" in val["client"]:
             raise ValidationError("Client name cannot contain the | character")
-
-        return val
-
-
-class SiteSerializer(ModelSerializer):
-    class Meta:
-        model = Site
-        fields = "__all__"
-
-    def validate(self, val):
-        if "|" in val["site"]:
-            raise ValidationError("Site name cannot contain the | character")
 
         return val
 

--- a/api/tacticalrmm/tacticalrmm/settings.py
+++ b/api/tacticalrmm/tacticalrmm/settings.py
@@ -11,7 +11,7 @@ AUTH_USER_MODEL = "accounts.User"
 
 # bump this version everytime vue code is changed
 # to alert user they need to manually refresh their browser
-APP_VER = "0.0.41"
+APP_VER = "0.0.42"
 
 # https://github.com/wh1te909/salt
 LATEST_SALT_VER = "1.0.3"

--- a/web/src/components/AutomatedTasksTab.vue
+++ b/web/src/components/AutomatedTasksTab.vue
@@ -53,6 +53,7 @@
                     v-close-popup
                     @click="showEditAutomatedTask = true"
                     v-if="!props.row.managed_by_policy"
+                    v-show="false"
                   >
                     <q-item-section side>
                       <q-icon name="edit" />

--- a/web/src/components/automation/AutomationManager.vue
+++ b/web/src/components/automation/AutomationManager.vue
@@ -113,6 +113,19 @@
                     </q-item-section>
                     <q-item-section>Edit</q-item-section>
                   </q-item>
+
+                  <q-item
+                    clickable
+                    v-close-popup
+                    @click="showCopyPolicyModal(props.row)"
+                    id="context-copy"
+                  >
+                    <q-item-section side>
+                      <q-icon name="content_copy" />
+                    </q-item-section>
+                    <q-item-section>Copy</q-item-section>
+                  </q-item>
+
                   <q-item
                     clickable
                     v-close-popup
@@ -189,7 +202,9 @@
                 >{{ patchPolicyText(props.row) }}</span>
               </q-td>
               <q-td>
-                <q-icon name="content-copy" />
+                <q-icon name="content_copy" size="1.5em" @click="showCopyPolicyModal(props.row)">
+                  <q-tooltip>Create a copy of this policy</q-tooltip>
+                </q-icon>
               </q-td>
             </q-tr>
           </template>
@@ -203,7 +218,7 @@
 
     <!-- policy form modal -->
     <q-dialog v-model="showPolicyFormModal" @hide="closePolicyFormModal">
-      <PolicyForm :pk="editPolicyId" @close="closePolicyFormModal" />
+      <PolicyForm :pk="editPolicyId" :copyPolicy="copyPolicy" @close="closePolicyFormModal" />
     </q-dialog>
 
     <!-- policy overview modal -->
@@ -255,6 +270,7 @@ export default {
       showPatchPolicyModal: false,
       policy: null,
       editPolicyId: null,
+      copyPolicy: null,
       selected: [],
       columns: [
         { name: "active", label: "Active", field: "active", align: "left" },
@@ -352,9 +368,14 @@ export default {
       this.editPolicyId = id;
       this.showPolicyFormModal = true;
     },
+    showCopyPolicyModal(policy) {
+      this.copyPolicy = policy;
+      this.showPolicyFormModal = true;
+    },
     closePolicyFormModal() {
       this.showPolicyFormModal = false;
       this.editPolicyId = null;
+      this.copyPolicyId = null;
       this.refresh();
     },
     showAddPolicyModal() {

--- a/web/src/components/automation/PolicyAutomatedTasksTab.vue
+++ b/web/src/components/automation/PolicyAutomatedTasksTab.vue
@@ -67,6 +67,7 @@
                     v-close-popup
                     @click="showEditAutomatedTask = true"
                     id="context-edit"
+                    v-show="false"
                   >
                     <q-item-section side>
                       <q-icon name="edit" />

--- a/web/src/components/automation/modals/PolicyForm.vue
+++ b/web/src/components/automation/modals/PolicyForm.vue
@@ -6,6 +6,12 @@
         <q-space />
         <q-btn icon="close" flat round dense v-close-popup />
       </q-card-section>
+      <q-card-section v-if="copyPolicy">
+        <div class="text-subtitle1">
+          You are copying checks and tasks from Policy:
+          <b>{{ copyPolicy.name }}</b> into a new policy.
+        </div>
+      </q-card-section>
       <q-card-section class="row">
         <div class="col-2">Name:</div>
         <div class="col-10">
@@ -43,19 +49,19 @@ import mixins, { notifySuccessConfig, notifyErrorConfig } from "@/mixins/mixins"
 export default {
   name: "PolicyForm",
   mixins: [mixins],
-  props: { pk: Number },
+  props: { pk: Number, copyPolicy: Object },
   data() {
     return {
       name: "",
       desc: "",
       enforced: false,
-      active: false
+      active: false,
     };
   },
   computed: {
     title() {
       return this.pk ? "Edit Policy" : "Add Policy";
-    }
+    },
   },
   methods: {
     getPolicy() {
@@ -83,7 +89,7 @@ export default {
         name: this.name,
         desc: this.desc,
         active: this.active,
-        enforced: this.enforced
+        enforced: this.enforced,
       };
 
       if (this.pk) {
@@ -99,6 +105,10 @@ export default {
             this.$q.notify(notifyErrorConfig(e.response.data));
           });
       } else {
+        if (this.copyPolicy) {
+          formData.copyId = this.copyPolicy.id;
+        }
+
         this.$store
           .dispatch("automation/addPolicy", formData)
           .then(r => {
@@ -111,13 +121,13 @@ export default {
             this.$q.notify(notifyErrorConfig(e.response.data));
           });
       }
-    }
+    },
   },
   mounted() {
     // If pk prop is set that means we are editting
     if (this.pk) {
       this.getPolicy();
     }
-  }
+  },
 };
 </script>

--- a/web/src/components/modals/agents/EditAgent.vue
+++ b/web/src/components/modals/agents/EditAgent.vue
@@ -170,7 +170,7 @@ export default {
   },
   methods: {
     getAgentInfo() {
-      axios.get(`/agents/${this.selectedAgentPk}/agentdetail/`).then(r => {
+      axios.get(`/agents/${this.selectedAgentPk}/agenteditdetails/`).then(r => {
         this.agent = r.data;
         this.allTimezones = Object.freeze(r.data.all_timezones);
 
@@ -206,9 +206,7 @@ export default {
         data.time_zone = this.timezone;
       }
 
-      delete data.services;
-      delete data.disks;
-      delete data.local_ip;
+      delete data.all_timezones;
 
       axios
         .patch("/agents/editagent/", data)

--- a/web/src/components/modals/coresettings/EditCoreSettings.vue
+++ b/web/src/components/modals/coresettings/EditCoreSettings.vue
@@ -38,6 +38,11 @@
                     class="col-6"
                   />
                 </q-card-section>
+                <q-card-section class="row">
+                  <div class="col-4">Reset Patch Policy on Agents:</div>
+                  <div class="col-2"></div>
+                  <q-btn color="negative" label="Reset" @click="resetPatchPolicyModal" />
+                </q-card-section>
               </q-tab-panel>
               <!-- alerts -->
               <q-tab-panel name="alerts">
@@ -191,18 +196,25 @@
         </q-form>
       </template>
     </q-splitter>
+
+    <q-dialog v-model="showResetPatchPolicyModal">
+      <ResetPatchPolicy @close="showResetPatchPolicyModal = false" />
+    </q-dialog>
   </q-card>
 </template>
 
 <script>
 import axios from "axios";
 import mixins from "@/mixins/mixins";
+import ResetPatchPolicy from "@/components/modals/coresettings/ResetPatchPolicy";
 
 export default {
   name: "EditCoreSettings",
+  components: { ResetPatchPolicy },
   mixins: [mixins],
   data() {
     return {
+      showResetPatchPolicyModal: false,
       ready: false,
       settings: {},
       email: null,
@@ -249,6 +261,9 @@ export default {
     removeEmail(email) {
       const removed = this.settings.email_alert_recipients.filter(k => k !== email);
       this.settings.email_alert_recipients = removed;
+    },
+    resetPatchPolicyModal() {
+      this.showResetPatchPolicyModal = true;
     },
     editSettings() {
       this.$q.loading.show();

--- a/web/src/components/modals/coresettings/ResetPatchPolicy.vue
+++ b/web/src/components/modals/coresettings/ResetPatchPolicy.vue
@@ -1,0 +1,118 @@
+<template>
+  <q-card style="min-width: 400px">
+    <q-card-section class="row">
+      <q-card-actions align="left">
+        <div class="text-h6">Reset Agent Patch Policy</div>
+      </q-card-actions>
+      <q-space />
+      <q-card-actions align="right">
+        <q-btn v-close-popup flat round dense icon="close" />
+      </q-card-actions>
+    </q-card-section>
+    <q-card-section>
+      <div class="text-subtitle3">
+        Reset the patch policies for agents in a specific client or site.
+        You can also leave the client and site blank to reset the patch policy for all agents.
+        (This might take a while)
+      </div>
+      <q-form @submit.prevent="submit">
+        <q-card-section>
+          <q-select
+            label="Clients"
+            @clear="clearClient"
+            clearable
+            options-dense
+            outlined
+            v-model="client"
+            :options="client_options"
+          />
+        </q-card-section>
+        <q-card-section>
+          <q-select
+            :disabled="client === null"
+            @clear="clearSite"
+            label="Sites"
+            clearable
+            options-dense
+            outlined
+            v-model="site"
+            :options="site_options"
+          />
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn label="Reset Policies" color="primary" type="submit" />
+          <q-btn label="Cancel" v-close-popup />
+        </q-card-actions>
+      </q-form>
+    </q-card-section>
+  </q-card>
+</template>
+
+<script>
+import { notifySuccessConfig, notifyErrorConfig } from "@/mixins/mixins";
+
+export default {
+  name: "ResetPatchPolicy",
+  data() {
+    return {
+      client: null,
+      site: null,
+      client_options: [],
+    };
+  },
+  methods: {
+    submit() {
+      this.$q.loading.show();
+
+      let data = {};
+
+      if (this.client !== null) {
+        data.client = this.client.label;
+      }
+
+      if (this.site !== null) {
+        data.site = this.site.label;
+      }
+
+      this.$store
+        .dispatch("automation/resetPatchPolicies", data)
+        .then(r => {
+          this.$q.loading.hide();
+          this.$q.notify(notifySuccessConfig("The agent policies were reset successfully!"));
+          this.$emit("close");
+        })
+        .catch(e => {
+          this.$q.notify(notifyErrorConfig("There was an error reseting policies"));
+        });
+    },
+    getClients() {
+      this.$store
+        .dispatch("loadClients")
+        .then(r => {
+          this.client_options = r.data.map(client => ({ label: client.client, value: client.id, sites: client.sites }));
+        })
+        .catch(e => {
+          this.$q.notify(notifyErrorConfig("There was an error loading the clients!"));
+        });
+    },
+    clearClient() {
+      this.client = null;
+      this.site = null;
+    },
+    clearSite() {
+      this.site = null;
+    },
+  },
+  computed: {
+    site_options() {
+      return !!this.client ? this.client.sites.map(site => ({ label: site.site, value: site.id })) : [];
+    },
+    buttonText() {
+      return !!this.client ? "Clear Policies for ALL Agents" : "Clear Policies";
+    },
+  },
+  mounted() {
+    this.getClients();
+  },
+};
+</script>

--- a/web/src/store/automation.js
+++ b/web/src/store/automation.js
@@ -98,6 +98,9 @@ export default {
     },
     deletePatchPolicy(context, pk) {
       return axios.delete(`/automation/winupdatepolicy/${pk}/`)
+    },
+    resetPatchPolicies(context, data) {
+      return axios.patch("/automation/winupdatepolicy/reset/", data)
     }
   }
 }

--- a/web/src/store/index.js
+++ b/web/src/store/index.js
@@ -197,7 +197,7 @@ export default function () {
         });
       },
       loadClients(context) {
-        return axios.get("/clients/listclients/");
+        return axios.get("/clients/clients/");
       },
       loadSites(context) {
         return axios.get("/clients/listsites/");


### PR DESCRIPTION
This allows for modifying the agent patch policy in bulk from the core settings page