### PR TITLE
Avoid multiple update file versions

### DIFF
--- a/docs/docs/update_server.md
+++ b/docs/docs/update_server.md
@@ -20,7 +20,7 @@ SSH into your server as the linux user you created during install.<br/><br/>
 __Never__ run any update scripts or commands as the `root` user.<br/>This will mess up permissions and break your installation.<br/><br/>
 Download the update script and run it:<br/>
 ```bash
-wget https://raw.githubusercontent.com/wh1te909/tacticalrmm/master/update.sh
+wget -N https://raw.githubusercontent.com/wh1te909/tacticalrmm/master/update.sh
 chmod +x update.sh
 ./update.sh
 ```


### PR DESCRIPTION
Kept getting update.sh.1, update.sh.2 etc with each run and then the auto-pasted command wouldn't be running the latest version of the file.

![2021-03-13 12_12_14-TRMM multiple update files](https://user-images.githubusercontent.com/13395348/111038224-dcd36600-83f5-11eb-93b2-93e6c96c142c.png)
