### PR TITLE
fixed paths

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -13,8 +13,8 @@ python3 -m venv env
 source env/bin/activate
 pip install --upgrade pip
 pip install --upgrade setuptools wheel
-pip install -r api/tacticalrmm/requirements-dev.txt
-cd docs
+pip install -r tacticalrmm/api/tacticalrmm/requirements-dev.txt
+cd tacticalrmm/docs
 mkdocs serve
 ```
 


### PR DESCRIPTION
Following the documentation Contributing > Contributing to docs > Setting up local environment

The user should either cd into tacticalrmm or we fix the paths in the docs. Whatever you choose