### PR TITLE
Update Win_Firewall_Check_Status.ps1

### DIFF
--- a/scripts/Win_Firewall_Check_Status.ps1
+++ b/scripts/Win_Firewall_Check_Status.ps1
@@ -1,16 +1,16 @@
 $ErrorActionPreference = 'silentlycontinue'
 $fwenabled = (get-netfirewallprofile -policystore activestore).Enabled
 
-if ($fwenabled.Contains('True')) {
-    Write-Output "Firewall is Enabled"
-    netsh advfirewall show currentprofile
-    exit 0
+if ($fwenabled.Contains('False')) {
+    Write-Output "Firewall is Disabled"
+    exit 1
 }
 
 
 else {
-    Write-Host "Firewall is Disabled"
-    exit 1
+    Write-Host "Firewall is Enabled"
+    netsh advfirewall show currentprofile
+    exit 0
 }
 
 


### PR DESCRIPTION
Fix windows firewall script monitor to correctly trigger if any of 3 firewalls are disabled. Fixes issue #587