### PR TITLE
Update Win_Defender_QuickScan_Background.ps1

### DIFF
--- a/scripts/Win_Defender_QuickScan_Background.ps1
+++ b/scripts/Win_Defender_QuickScan_Background.ps1
@@ -1,2 +1,2 @@
-﻿Write-Host "Running Windows Defender Full Scan in Background" -ForegroundColor Green
-Start-MpScan -ScanPath C:\ -ScanType QuickScan -AsJob
+﻿Write-Host "Running Windows Defender Quick Scan in Background" -ForegroundColor Green
+Start-MpScan -ScanType QuickScan -AsJob


### PR DESCRIPTION
I did some tests and don't see value in specifying a drive letter. `QuickScanAge` resets to 0 even without a drive letter.

Having a drive letter seems to also assume something that may not be true.