### PR TITLE
Specify the config path for nats-api

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -468,7 +468,7 @@ After=nats.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/nats-api
+ExecStart=/usr/local/bin/nats-api  -config /rmm/api/tacticalrmm/nats-api.conf
 User=${USER}
 Group=${USER}
 Restart=always

--- a/update.sh
+++ b/update.sh
@@ -131,7 +131,7 @@ After=nats.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/nats-api
+ExecStart=/usr/local/bin/nats-api -config /rmm/api/tacticalrmm/nats-api.conf
 User=${USER}
 Group=${USER}
 Restart=always


### PR DESCRIPTION
Specify the config path for `nats-api` over using a hard-coded config path. This provides clarity when looking for the configuration.