### PR TITLE
Change timeout method

### DIFF
--- a/scripts/Win_Printer_ClearandRestart.bat
+++ b/scripts/Win_Printer_ClearandRestart.bat
@@ -2,7 +2,7 @@
 
 sc stop spooler
 
-timeout /t 5 /nobreak > NUL
+ping 127.0.0.1 -n 6 > nul
 
 del C:\Windows\System32\spool\printers\* /Q /F /S
 


### PR DESCRIPTION
The current timeout results in an error "ERROR: Input redirection is not supported, exiting the process immediately.".

Reusing the ping tool to act as a timeout resolves this error because the batch script is not producing a user interruptable timeout but will still produce a 4-5 second timeout.

*Resubmitting PR from master to develop branch