### PR TITLE
Make cert pub & private paths configurable

### DIFF
--- a/docker/containers/tactical-nginx/entrypoint.sh
+++ b/docker/containers/tactical-nginx/entrypoint.sh
@@ -12,8 +12,8 @@ set -e
 : "${WEBSOCKETS_SERVICE:=tactical-websockets}"
 : "${DEV:=0}"
 
-CERT_PRIV_PATH=${TACTICAL_DIR}/certs/privkey.pem
-CERT_PUB_PATH=${TACTICAL_DIR}/certs/fullchain.pem
+: "${CERT_PRIV_PATH}:=${TACTICAL_DIR}/certs/privkey.pem"
+: "${CERT_PUB_PATH}:=${TACTICAL_DIR}/certs/fullchain.pem"
 
 mkdir -p "${TACTICAL_DIR}/certs"
 

--- a/docker/containers/tactical/entrypoint.sh
+++ b/docker/containers/tactical/entrypoint.sh
@@ -18,6 +18,8 @@ set -e
 : "${APP_HOST:=tactical-frontend}"
 : "${REDIS_HOST:=tactical-redis}"
 
+: "${CERT_PRIV_PATH}:=${TACTICAL_DIR}/certs/privkey.pem"
+: "${CERT_PUB_PATH}:=${TACTICAL_DIR}/certs/fullchain.pem"
 
 function check_tactical_ready {
   sleep 15
@@ -62,8 +64,8 @@ DEBUG = False
 
 DOCKER_BUILD = True
 
-CERT_FILE = '/opt/tactical/certs/fullchain.pem'
-KEY_FILE = '/opt/tactical/certs/privkey.pem'
+CERT_FILE = ${CERT_PUB_PATH}
+KEY_FILE = ${CERT_PRIV_PATH}
 
 EXE_DIR = '/opt/tactical/api/tacticalrmm/private/exe'
 LOG_DIR = '/opt/tactical/api/tacticalrmm/private/log'


### PR DESCRIPTION
This is another PR in relation to making tacticalrmm work better in clustered setups e.g. Kubernetes, see https://github.com/wh1te909/tacticalrmm/issues/906

This change makes the certificate public & private paths configurable so we can can mount external certificates into the pod / container without needing to copy, rename or use a subPath.

The reason for doing it this way is so that the certificates can be renewed automatically without needing to restart the container / pod.