### PR TITLE
Update get_mesh_exe_url command to use MESH_WS_URL for docker

### DIFF
--- a/api/tacticalrmm/core/management/commands/get_mesh_exe_url.py
+++ b/api/tacticalrmm/core/management/commands/get_mesh_exe_url.py
@@ -17,8 +17,7 @@ class Command(BaseCommand):
         token = get_auth_token(mesh_settings.mesh_username, mesh_settings.mesh_token)
 
         if settings.DOCKER_BUILD:
-            site = mesh_settings.mesh_site.replace("https", "ws")
-            uri = f"{site}:443/control.ashx?auth={token}"
+            uri = f"{settings.MESH_WS_URL}/control.ashx?auth={token}"
         else:
             site = mesh_settings.mesh_site.replace("https", "wss")
             uri = f"{site}/control.ashx?auth={token}"


### PR DESCRIPTION
See https://github.com/wh1te909/tacticalrmm/commit/e564500480d37a1f1c81f8e08df002fae3aa7ca2