### PR TITLE
Add option to enable webSocketMaskOverride in MeshCentral config

### DIFF
--- a/docker/containers/tactical-meshcentral/entrypoint.sh
+++ b/docker/containers/tactical-meshcentral/entrypoint.sh
@@ -10,6 +10,7 @@ set -e
 : "${MONGODB_PORT:=27017}"
 : "${NGINX_HOST_IP:=172.20.0.20}"
 : "${MESH_PERSISTENT_CONFIG:=0}"
+: "${WS_MASK_OVERRIDE:=0}"
 
 mkdir -p /home/node/app/meshcentral-data
 mkdir -p ${TACTICAL_DIR}/tmp
@@ -50,7 +51,8 @@ mesh_config="$(cat << EOF
       "NewAccounts": false,
       "mstsc": true,
       "GeoLocation": true,
-      "CertUrl": "https://${NGINX_HOST_IP}:443"
+      "CertUrl": "https://${NGINX_HOST_IP}:443",
+      "agentConfig": [ "webSocketMaskOverride=${WS_MASK_OVERRIDE}" ]
     }
   }
 }


### PR DESCRIPTION
This PR adds an option to enable the following option in the MeshCentral config, for compatibility with Traefik in Docker / Kubernetes setups.

```"agentConfig": [ "webSocketMaskOverride=1" ]```

See https://meshcentral.com/info/docs/MeshCentral2UserGuide.pdf as well as [this config example](https://gitlab.com/NiceGuyIT/tactical-goodies/-/tree/main/traefik#meshcentral) from @NiceGuyIT for more info.