### PR TITLE
Replace inotify with custom config watcher script

### DIFF
--- a/docker/containers/tactical-nats/entrypoint.sh
+++ b/docker/containers/tactical-nats/entrypoint.sh
@@ -3,6 +3,7 @@
 set -e
 
 : "${DEV:=0}"
+: "${NATS_CONFIG_CHECK_INTERVAL:=5}"
 
 if [ "${DEV}" = 1 ]; then
   NATS_CONFIG=/workspace/api/tacticalrmm/nats-rmm.conf
@@ -20,7 +21,7 @@ done
 
 config_watcher="$(cat << EOF
 while true; do
-    sleep 15;
+    sleep ${NATS_CONFIG_CHECK_INTERVAL};
     if [[ ! -z \${NATS_CHECK} ]]; then
         NATS_RELOAD=\$(date -r '/opt/tactical/api/nats-rmm.conf')
         if [[ \$NATS_RELOAD == \$NATS_CHECK ]]; then


### PR DESCRIPTION
This PR replaces inotify with a custom config watcher script.

The reason for this change is that inotify doesn't work well across all container environments, see https://github.com/docker/for-mac/issues/2375 and https://william-yeh.net/post/2019/06/inotify-in-containers/ for details.

This change in particular works fine in Docker but also fixes the problem with inotify failing in Kubernetes!

Tested:
- Docker on WSL2 -> Works
- Kubernetes -> Works
- Reloading NATS from the dashboard -> Works
- Generating & installing a new agent -> Works
- Manually killing the process inside the container -> supervisord restarts it, which is the desired behavior to make sure the script stays running

Thank you,