### PR TITLE
Get Anydesk ID for licensed or unlicensed installs.

### DIFF
--- a/scripts/Win_AnyDesk_Get_Anynet_ID.ps1
+++ b/scripts/Win_AnyDesk_Get_Anynet_ID.ps1
@@ -6,7 +6,9 @@ foreach ($Path in $Paths) {
     }
 }
 
-$ConfigPath = $GoodPath + "\AnyDesk\system.conf"
+$SystemFile = get-childitem -Path $GoodPath -Filter "system.conf" -Recurse -ErrorAction SilentlyContinue
+
+$ConfigPath = $SystemFile.FullName
 
 $ResultsIdSearch = Select-String -Path $ConfigPath -Pattern ad.anynet.id
 


### PR DESCRIPTION
Licensed AnyDesk installs do not save system.conf file to the $GoodPath\AnyDesk directory.  Searches subdirectories of $GoodPath for system.conf and uses the result to get the ID from.